### PR TITLE
Set PATH in boot2docker example shell function

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you are using boot2docker, you can use the function below, to:
 ```
 docker-enter() {
   boot2docker ssh '[ -f /var/lib/boot2docker/nsenter ] || docker run --rm -v /var/lib/boot2docker/:/target jpetazzo/nsenter'
-  boot2docker ssh -t sudo /var/lib/boot2docker/docker-enter "$@"
+  boot2docker ssh -t PATH=/var/lib/boot2docker:$PATH sudo docker-enter "$@"
 }
 ```
 


### PR DESCRIPTION
I installed `nsenter` following the instructions given in [Chris Jones'
post][0] to get setup with boot2docker on Mac OS X. I added his example
script to run `/bin/bash` if none is given (which is based on the shell
function in `nsenter`'s README), and upon trying to enter my container,
got this error message:

    /var/lib/boot2docker/docker-enter: line 43: importenv: not found
    error in run: exit status 127

Evidently, `/var/lib/boot2docker/importenv` is not on the path, so this
change sets `PATH` when SSHing to the boot2docker VM and successfully
enters the target container with no error message.

[0]: http://viget.com/extend/how-to-use-docker-on-os-x-the-missing-guide